### PR TITLE
Allow customizing ssh host alias to other things than org title

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,10 @@
 
    For a heading to be exported as a host, it must have either a
    =HOSTNAME= or =IP= property. If an entry has both, =IP= takes
-   precedence. It can also contain one or more
+   precedence. The host alias will be equal to the org title
+   or be overriden by the property =HOST_OVERRIDE=, if it is defined.
+
+   It can also contain one or more
    optional parameters, listed in the table below.
 
    | [[https://man.openbsd.org/man5/ssh_config.5][ssh_config(5)]] option             | ox-ssh property                            |

--- a/ox-ssh.el
+++ b/ox-ssh.el
@@ -176,7 +176,7 @@
   "Transform HEADLINE and CONTENTS into SSH config host."
   (let* ((hostname (org-element-property :HOSTNAME headline))
          (ip (org-element-property :IP headline))
-         (host (org-element-property :raw-value headline))
+         (host (or (org-element-property :HOST_OVERRIDE headline) (org-element-property :raw-value headline)))
          (addr (or ip hostname)))
     (if addr
         (let ((ssh-add-keys-to-agent (org-element-property :SSH_ADD_KEYS_TO_AGENT headline))


### PR DESCRIPTION
I want to name the title differently than what I want to appear as the host alias in the resulting ssh config in some cases. This adds the `:HOST_OVERRIDE:` property that takes precedence over the org title.

So for example:
```org
* My Node
:PROPERTIES:
:IP: 192.168.1.1
:HOST_OVERRIDE: my-node
:END:
```

Will output:
```
Host my-node
  HostName 192.168.1.1

```